### PR TITLE
Fixed typo in HAWC2 model

### DIFF
--- a/HAWC2/IEA-22-280-RWT-Semi/htc/_master/iea_22mw_rwt_floater_master_dlb.htc
+++ b/HAWC2/IEA-22-280-RWT-Semi/htc/_master/iea_22mw_rwt_floater_master_dlb.htc
@@ -115,7 +115,6 @@ begin new_htc_structure;
     end  timoschenko_input ;
     begin  c2_def ;
       nsec 3 ;
-      nsec 3 ;
       sec  1  0.0e+00  0.0e+00 0.0e+00  0.0e+00 ;
       sec  2  0.0e+00  0.0e+00 32.0e+00  0.0e+00 ;
       sec  3  0.0e+00  0.0e+00 40.0e+00  0.0e+00 ;

--- a/HAWC2/IEA-22-280-RWT-Semi/htc/iea_22mw_rwt_floater_steps.htc
+++ b/HAWC2/IEA-22-280-RWT-Semi/htc/iea_22mw_rwt_floater_steps.htc
@@ -116,7 +116,6 @@ begin new_htc_structure;
     end  timoschenko_input ;
     begin  c2_def ;
       nsec 3 ;
-      nsec 3 ;
       sec  1  0.0e+00  0.0e+00 0.0e+00  0.0e+00 ;
       sec  2  0.0e+00  0.0e+00 32.0e+00  0.0e+00 ;
       sec  3  0.0e+00  0.0e+00 40.0e+00  0.0e+00 ;


### PR DESCRIPTION
Removed repeated command `nsec` in HAWC2 semisub model.